### PR TITLE
Replace vanilla OpenJDK with Temurin

### DIFF
--- a/java/java-jre11/Dockerfile
+++ b/java/java-jre11/Dockerfile
@@ -3,22 +3,32 @@
 # Image: ghcr.io/sparkedhost/images:java-jre11
 # ----------------------------------
 
-FROM        openjdk:11-slim-bullseye
+FROM        debian:bullseye-slim
 
 LABEL       author="DevOps Team at Sparked Host" maintainer="sysadmin@sparkedhost.com"
 
 RUN apt-get update -y \
- && apt-get install fontconfig iproute2 curl ca-certificates -y \
- && useradd -d /home/container -m container
+ && apt-get install fontconfig iproute2 curl ca-certificates tar -y \
+ && useradd -d /home/container -m container \
+ && mkdir -p /opt/java
 
+# Download pre-built Temurin JRE binaries
+ADD https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.18%2B10/OpenJDK11U-jre_x64_linux_hotspot_11.0.18_10.tar.gz /opt/java/java.tar.gz
+RUN tar -C /opt/java --strip-components=1 -xzf /opt/java/java.tar.gz \
+ && rm -f /opt/java/java.tar.gz
+
+# Add Sparked certificate authority
 ADD ca.crt /usr/local/share/ca-certificates/sparked-ca.crt
 RUN chmod 644 /usr/local/share/ca-certificates/sparked-ca.crt && update-ca-certificates
 
+# Set user that will run the entrypoint script, and overwrite USER, HOME and PATH environment variables
+# We need to inject the path to the Java binaries in the PATH environment variable
 USER container
-ENV  USER=container HOME=/home/container
+ENV  USER=container HOME=/home/container    PATH="$PATH:/opt/java/bin"
 
 WORKDIR     /home/container
 
 COPY        ./entrypoint.sh /entrypoint.sh
 
 CMD         ["/bin/bash", "/entrypoint.sh"]
+

--- a/java/java-jre16/Dockerfile
+++ b/java/java-jre16/Dockerfile
@@ -3,22 +3,33 @@
 # Image: ghcr.io/sparkedhost/images:java-jre16
 # ----------------------------------
 
-FROM        openjdk:16-slim-bullseye
+FROM        debian:bullseye-slim
 
 LABEL       author="DevOps Team at Sparked Host" maintainer="sysadmin@sparkedhost.com"
 
 RUN apt-get update -y \
- && apt-get install fontconfig iproute2 curl ca-certificates -y \
- && useradd -d /home/container -m container
+ && apt-get install fontconfig iproute2 curl ca-certificates tar -y \
+ && useradd -d /home/container -m container \
+ && mkdir -p /opt/java
 
+# Download pre-built Temurin JRE binaries
+# Pre-compiled by Sparked Host using https://github.com/adoptium/temurin-build
+ADD https://s3-modpacks.sparkedhost.us/OpenJDK16U-jre_x64_linux_hotspot_16.0.2%2B7.tar.gz /opt/java/java.tar.gz
+RUN tar -C /opt/java --strip-components=1 -xzf /opt/java/java.tar.gz \
+ && rm -f /opt/java/java.tar.gz
+
+# Add Sparked certificate authority
 ADD ca.crt /usr/local/share/ca-certificates/sparked-ca.crt
 RUN chmod 644 /usr/local/share/ca-certificates/sparked-ca.crt && update-ca-certificates
 
+# Set user that will run the entrypoint script, and overwrite USER, HOME and PATH environment variables
+# We need to inject the path to the Java binaries in the PATH environment variable
 USER container
-ENV  USER=container HOME=/home/container
+ENV  USER=container HOME=/home/container    PATH="$PATH:/opt/java/bin"
 
 WORKDIR     /home/container
 
 COPY        ./entrypoint.sh /entrypoint.sh
 
 CMD         ["/bin/bash", "/entrypoint.sh"]
+

--- a/java/java-jre17/Dockerfile
+++ b/java/java-jre17/Dockerfile
@@ -3,22 +3,32 @@
 # Image: ghcr.io/sparkedhost/images:java-jre17
 # ----------------------------------
 
-FROM        openjdk:17-slim-bullseye
+FROM        debian:bullseye-slim
 
 LABEL       author="DevOps Team at Sparked Host" maintainer="sysadmin@sparkedhost.com"
 
 RUN apt-get update -y \
- && apt-get install fontconfig iproute2 curl ca-certificates -y \
- && useradd -d /home/container -m container
+ && apt-get install fontconfig iproute2 curl ca-certificates tar -y \
+ && useradd -d /home/container -m container \
+ && mkdir -p /opt/java
 
+# Download pre-built Temurin JRE binaries
+ADD https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.6%2B10/OpenJDK17U-jdk-sources_17.0.6_10.tar.gz /opt/java/java.tar.gz
+RUN tar -C /opt/java --strip-components=1 -xzf /opt/java/java.tar.gz \
+ && rm -f /opt/java/java.tar.gz
+
+# Add Sparked certificate authority
 ADD ca.crt /usr/local/share/ca-certificates/sparked-ca.crt
 RUN chmod 644 /usr/local/share/ca-certificates/sparked-ca.crt && update-ca-certificates
 
+# Set user that will run the entrypoint script, and overwrite USER, HOME and PATH environment variables
+# We need to inject the path to the Java binaries in the PATH environment variable
 USER container
-ENV  USER=container HOME=/home/container
+ENV  USER=container HOME=/home/container    PATH="$PATH:/opt/java/bin"
 
 WORKDIR     /home/container
 
 COPY        ./entrypoint.sh /entrypoint.sh
 
 CMD         ["/bin/bash", "/entrypoint.sh"]
+

--- a/java/java-jre17/Dockerfile
+++ b/java/java-jre17/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update -y \
  && mkdir -p /opt/java
 
 # Download pre-built Temurin JRE binaries
-ADD https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.6%2B10/OpenJDK17U-jdk-sources_17.0.6_10.tar.gz /opt/java/java.tar.gz
+ADD https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.6%2B10/OpenJDK17U-jdk_x64_linux_hotspot_17.0.6_10.tar.gz /opt/java/java.tar.gz
 RUN tar -C /opt/java --strip-components=1 -xzf /opt/java/java.tar.gz \
  && rm -f /opt/java/java.tar.gz
 

--- a/java/java-jre18/Dockerfile
+++ b/java/java-jre18/Dockerfile
@@ -3,22 +3,32 @@
 # Image: ghcr.io/sparkedhost/images:java-jre18
 # ----------------------------------
 
-FROM        openjdk:18-slim-bullseye
+FROM        debian:bullseye-slim
 
 LABEL       author="DevOps Team at Sparked Host" maintainer="sysadmin@sparkedhost.com"
 
 RUN apt-get update -y \
- && apt-get install fontconfig iproute2 curl ca-certificates -y \
- && useradd -d /home/container -m container
+ && apt-get install fontconfig iproute2 curl ca-certificates tar -y \
+ && useradd -d /home/container -m container \
+ && mkdir -p /opt/java
 
+# Download pre-built Temurin JRE binaries
+ADD https://github.com/adoptium/temurin18-binaries/releases/download/jdk-18.0.2.1%2B1/OpenJDK18U-jre_x64_linux_hotspot_18.0.2.1_1.tar.gz /opt/java/java.tar.gz
+RUN tar -C /opt/java --strip-components=1 -xzf /opt/java/java.tar.gz \
+ && rm -f /opt/java/java.tar.gz
+
+# Add Sparked certificate authority
 ADD ca.crt /usr/local/share/ca-certificates/sparked-ca.crt
 RUN chmod 644 /usr/local/share/ca-certificates/sparked-ca.crt && update-ca-certificates
 
+# Set user that will run the entrypoint script, and overwrite USER, HOME and PATH environment variables
+# We need to inject the path to the Java binaries in the PATH environment variable
 USER container
-ENV  USER=container HOME=/home/container
+ENV  USER=container HOME=/home/container    PATH="$PATH:/opt/java/bin"
 
 WORKDIR     /home/container
 
 COPY        ./entrypoint.sh /entrypoint.sh
 
 CMD         ["/bin/bash", "/entrypoint.sh"]
+

--- a/java/java-jre8/Dockerfile
+++ b/java/java-jre8/Dockerfile
@@ -3,19 +3,28 @@
 # Image: ghcr.io/sparkedhost/images:java-jre8
 # ----------------------------------
 
-FROM        openjdk:8-slim-bullseye
+FROM        debian:bullseye-slim
 
 LABEL       author="DevOps Team at Sparked Host" maintainer="sysadmin@sparkedhost.com"
 
 RUN apt-get update -y \
- && apt-get install fontconfig iproute2 curl ca-certificates -y \
- && useradd -d /home/container -m container
+ && apt-get install fontconfig iproute2 curl ca-certificates tar -y \
+ && useradd -d /home/container -m container \
+ && mkdir -p /opt/java
 
+# Download pre-built Temurin JRE binaries
+ADD https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u362-b09/OpenJDK8U-jre_x64_linux_hotspot_8u362b09.tar.gz /opt/java/java.tar.gz
+RUN tar -C /opt/java --strip-components=1 -xzf /opt/java/java.tar.gz \
+ && rm -f /opt/java/java.tar.gz
+
+# Add Sparked certificate authority
 ADD ca.crt /usr/local/share/ca-certificates/sparked-ca.crt
 RUN chmod 644 /usr/local/share/ca-certificates/sparked-ca.crt && update-ca-certificates
 
+# Set user that will run the entrypoint script, and overwrite USER, HOME and PATH environment variables
+# We need to inject the path to the Java binaries in the PATH environment variable
 USER container
-ENV  USER=container HOME=/home/container
+ENV  USER=container HOME=/home/container    PATH="$PATH:/opt/java/bin"
 
 WORKDIR     /home/container
 


### PR DESCRIPTION
Closes #13 

This PR replaces vanilla OpenJDK binaries with Eclipse Temurin (JRE-only binaries). Compatibility should be the same. This allows us to more easily update the Java binaries we ship with our images, as we only have to replace the link inside each ``Dockerfile``. Using JRE-only packages also lowers the image size, see:

```
REPOSITORY                           TAG               IMAGE ID       CREATED          SIZE
ghcr.io/sparkedhost/images-testing   java-jre16-slim   7a4507341e15   27 minutes ago   316MB
ghcr.io/sparkedhost/images           java-jre16        00685a6ac20d   7 days ago       436MB
ghcr.io/pterodactyl/yolks            java_16           d04e2d3fb71f   4 weeks ago      635MB
```

We could potentially automate this in the future, too, although this one-liner could result in unpredictable behavior as it relies on the objects in the response array being in the exact same order every time:

**UPDATE: it pulled the sources link when I ran the command for JDK 17, do not use this one-liner!**

```bash
curl -sL "https://api.adoptium.net/v3/assets/latest/17/hotspot?os=linux&architecture=x64" | jq .[3].binary.package.link
```

*(replace 17 with the JDK version you want)*

I had to compile JDK 16 locally as it's now EOL and I couldn't find a JRE-only package for it. It hasn't received updates since 2021 though, so we won't find ourselves recompiling Java every month.