### PR TITLE
Updating Unturned Images

### DIFF
--- a/games/unturned-preview/Dockerfile
+++ b/games/unturned-preview/Dockerfile
@@ -3,7 +3,7 @@
 # Image: ghcr.io/sparkedhost/images:games-unturned-preview
 # ----------------------------------
 
-FROM ubuntu:22.04
+FROM debian:bullseye-slim
 
 LABEL author="DevOps Team at Sparked Host" maintainer="sysadmin@sparkedhost.com"
 
@@ -11,7 +11,7 @@ ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt update
 RUN apt upgrade -y
-RUN apt install -y curl wget jq screen htop unzip lib32stdc++6 libc6 libgdiplus libgl1-mesa-glx libxcursor1 libxrandr2 libc6-dev
+RUN apt install -y curl wget jq unzip libc6-dev libx11-dev lib32gcc-s1
 RUN useradd -d /home/container -m container
 
 USER container

--- a/games/unturned-preview/entrypoint.sh
+++ b/games/unturned-preview/entrypoint.sh
@@ -3,14 +3,10 @@ sleep 1
 
 cd /home/container
 
-if [ "${STEAM_ACC}" == "GSLToken Not Set" ]; then
-    echo "game server token not set"
-fi
-
-./steam/steamcmd.sh +force_install_dir /home/container +login anonymous +app_update 1110390 -beta preview +quit
-
 if [ "${GAME_AUTOUPDATE}" == "1" ]; then
     ./steam/steamcmd.sh +@sSteamCmdForcePlatformBitness 64 +force_install_dir /home/container +login anonymous +app_update 1110390 -beta preview +quit
+else
+    echo -e "Not updating game server as auto update is off. Starting Server"
 fi
 
 if [ "${OPENMOD_AUTOUPDATE}" == "1" ]; then
@@ -25,7 +21,8 @@ fi
 
 if [ "${USCRIPT_AUTOUPDATE}" == "1" ]; then
     wget https://trillionservers.com/unturned-egg/uScript.Unturned.zip
-	unzip -o -q uScript.Unturned.zip -d Modules && rm uScript.Unturned.zip
+    cd /home/container
+	unzip -o -q uScript.Unturned.zip -d Modules/uScript.Unturned && rm uScript.Unturned.zip
 fi
 
 mkdir -p Unturned_Headless_Data/Plugins/x86_64
@@ -34,9 +31,9 @@ cp -f steam/linux64/steamclient.so Unturned_Headless_Data/Plugins/x86_64/steamcl
 ulimit -n 2048
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/Unturned_Headless_Data/Plugins/x86_64/
 
-
-
 MODIFIED_STARTUP=$(eval echo $(echo ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g'))
+
+# Print startup command to console
 echo -e "\033[1;33mcustomer@sparkedhost:~\$\033[0m ${MODIFIED_STARTUP}"
 
 ${MODIFIED_STARTUP}

--- a/games/unturned/Dockerfile
+++ b/games/unturned/Dockerfile
@@ -3,7 +3,7 @@
 # Image: ghcr.io/sparkedhost/images:games-unturned
 # ----------------------------------
 
-FROM ubuntu:18.04
+FROM debian:bullseye-slim
 
 LABEL author="DevOps Team at Sparked Host" maintainer="sysadmin@sparkedhost.com"
 
@@ -11,7 +11,7 @@ ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt update
 RUN apt upgrade -y
-RUN apt install -y curl wget jq screen htop unzip lib32stdc++6 libc6 libgdiplus libgl1-mesa-glx libxcursor1 libxrandr2 libc6-dev
+RUN apt install -y curl wget jq unzip libc6-dev libx11-dev lib32gcc-s1
 RUN useradd -d /home/container -m container
 
 USER container

--- a/games/unturned/entrypoint.sh
+++ b/games/unturned/entrypoint.sh
@@ -3,20 +3,17 @@ sleep 1
 
 cd /home/container
 
-if [ "${STEAM_ACC}" == "GSLToken Not Set" ]; then
-    echo "game server token not set"
-fi
-
-./steam/steamcmd.sh +force_install_dir /home/container +login anonymous +app_update 1110390 +quit
-
 if [ "${GAME_AUTOUPDATE}" == "1" ]; then
     ./steam/steamcmd.sh +@sSteamCmdForcePlatformBitness 64 +force_install_dir /home/container +login anonymous +app_update 1110390 +quit
+else
+    echo -e "Not updating game server as auto update is off. Starting Server"
 fi
 
 if [ "${OPENMOD_AUTOUPDATE}" == "1" ]; then
     curl -s https://api.github.com/repos/openmod/OpenMod/releases/latest | jq -r ".assets[] | select(.name | contains(\"OpenMod.Unturned.Module\")) | .browser_download_url" | wget -i -
 	unzip -o -q OpenMod.Unturned.Module*.zip -d Modules && rm OpenMod.Unturned.Module*.zip
 fi
+
 
 if [ "${ROCKET_AUTOUPDATE}" == "1" ]; then
     cd /home/container
@@ -25,7 +22,8 @@ fi
 
 if [ "${USCRIPT_AUTOUPDATE}" == "1" ]; then
     wget https://trillionservers.com/unturned-egg/uScript.Unturned.zip
-	unzip -o -q uScript.Unturned.zip -d Modules && rm uScript.Unturned.zip
+    cd /home/container
+	unzip -o -q uScript.Unturned.zip -d Modules/uScript.Unturned && rm uScript.Unturned.zip
 fi
 
 mkdir -p Unturned_Headless_Data/Plugins/x86_64
@@ -34,10 +32,7 @@ cp -f steam/linux64/steamclient.so Unturned_Headless_Data/Plugins/x86_64/steamcl
 ulimit -n 2048
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/Unturned_Headless_Data/Plugins/x86_64/
 
-
-
 MODIFIED_STARTUP=$(eval echo $(echo ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g'))
-
 # Print startup command to console
 echo -e "\033[1;33mcustomer@sparkedhost:~\$\033[0m ${MODIFIED_STARTUP}"
 


### PR DESCRIPTION
-Changed to Bullseye-Slim
-Removed old packages
-Fixed steam updating no matter if auto-update was enabled
-Removed GSLT Token echo from Entrypoint.sh
-Fixed uScript unzipping in the wrong directory
Let me know if I messed up anywhere but these have been tested on my own servers and everything works as expected.(Plugin Loaders ETC) No egg changes are required.