### PR TITLE
fix: prevent steam failure from blocking mod install retry

### DIFF
--- a/games/spark-utils/spark-utils.sh
+++ b/games/spark-utils/spark-utils.sh
@@ -253,6 +253,7 @@ install_update_mods() { #[Input: str list of mods]
     local latest_update update_available mod_missing
     [[ -z $1 ]] && return
     [[ $1 == 0 ]] && return
+    rm -f /home/container/Steam/steamapps/workshop/*.acf
     echo -e "[MOD_INSTALLATION]: Checking for missing mods"
     for modID in $(echo "$1" | sed -e 's/@//g'); do
         if [[ $modID =~ ^[0-9]+$ ]]; then # Only check mods that are in ID-form


### PR DESCRIPTION
the steam acf file could hold metadata for failed downloads

for whatever reason, it does not retry these failed downloads, instead it complains that the failed files the metadata points to are not proper/do not exist 

deleting the acf forces a complete redownload of the mod

this won't redownload all mods, only the one supposed to be freshly installed or updated